### PR TITLE
Simulate with colour background that tiles are block when ends

### DIFF
--- a/lib/elixir_wordle_web/live/game_components/inputs_board.ex
+++ b/lib/elixir_wordle_web/live/game_components/inputs_board.ex
@@ -7,6 +7,7 @@ defmodule ElixirWordleWeb.InputsBoard do
   attr(:id, :string, required: true)
   attr(:attempts, :integer, required: true)
   attr(:columns, :integer, required: true)
+  attr(:end?, :boolean)
 
   @spec render(any) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
@@ -17,8 +18,10 @@ defmodule ElixirWordleWeb.InputsBoard do
           <%= for j <- 1..@columns do %>
             <div
               id={"input-#{i}-#{j}"}
-              class="font-semibold text-xl uppercase text-center text-gray-800
-               rounded p-2 border-2 min-h-[3rem] border-slate-300"
+              class={"font-semibold text-xl uppercase text-center text-gray-800
+               rounded p-2 border-2 min-h-[3rem] border-slate-300
+               #{@end? && " bg-slate-50"}"
+               }
             >
               <%= "\s" %>
             </div>

--- a/lib/elixir_wordle_web/live/wordle_live.ex
+++ b/lib/elixir_wordle_web/live/wordle_live.ex
@@ -101,6 +101,7 @@ defmodule ElixirWordleWeb.WordleLive do
           id="inputs-board"
           attempts={@game.attempts}
           columns={String.length(@game.answer)}
+          end?={Wordle.is_end?(@game)}
         />
       </div>
     <% else %>


### PR DESCRIPTION
# Simulate with colour background that tiles are block when ends

## Description

Simulate with colour background that tiles are block to give feedback to the user that you can not continue writting

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [ ] Test
- [ ] Documentation
- [ ] Keep updated translations (.po)
- [ ] Update changelog
