### PR TITLE
Improvement: Results current time and countdown only after display_results event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 0.2.0
 
+### Frontend & LiveViewServer
+
+- The next word countdown is initialized when Wordle game ends, rather than in the beginning as it can be a heavy workload.
 - Fixing the issue where creating unrealistic dates, such as adding 1 day to today's date resulting in a date like 32.
 
 ### Documentation

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,4 +34,4 @@ config :wallaby,
 config :elixir_wordle, :words_api, ElixirWordle.MockWordsAPI
 
 # End results delay to 0
-config :elixir_wordle, :end_delay, 0
+config :elixir_wordle, :display_results_delay, 0

--- a/lib/elixir_wordle_web/live/game_components/results.ex
+++ b/lib/elixir_wordle_web/live/game_components/results.ex
@@ -12,7 +12,7 @@ defmodule ElixirWordleWeb.Results do
   attr(:win?, :boolean, required: true)
   attr(:feedback, :list, default: [])
   attr(:show, :boolean, default: false)
-  attr(:current_time, :any, default: DateTime.utc_now())
+  attr(:current_time, DateTime, default: DateTime.utc_now())
 
   def render(assigns) do
     ~H"""

--- a/lib/elixir_wordle_web/live/wordle_live.ex
+++ b/lib/elixir_wordle_web/live/wordle_live.ex
@@ -33,10 +33,7 @@ defmodule ElixirWordleWeb.WordleLive do
     end
   end
 
-  def mount(_params, _session, socket) do
-    schedule(:update_clock)
-    {:ok, socket |> new_game() |> assign(current_time: DateTime.utc_now())}
-  end
+  def mount(_params, _session, socket), do: {:ok, socket |> new_game()}
 
   def handle_event("submit", %{"guess" => guess}, %{assigns: %{game: old_game}} = socket) do
     case Wordle.play(old_game, guess) do
@@ -48,6 +45,7 @@ defmodule ElixirWordleWeb.WordleLive do
             :noreply,
             socket
             |> assign(game: game, msg: "You #{(game.win? && "won") || "lost"} !")
+            |> assign(current_time: DateTime.utc_now())
             |> push_event("no_more_attempts", %{})
           }
         else
@@ -67,7 +65,10 @@ defmodule ElixirWordleWeb.WordleLive do
     end
   end
 
-  def handle_info(:ends, socket), do: {:noreply, socket |> assign(ends?: true)}
+  def handle_info(:ends, socket) do
+    schedule(:update_clock)
+    {:noreply, socket |> assign(ends?: true)}
+  end
 
   def handle_info(:next_word, socket), do: {:noreply, socket |> new_game()}
 


### PR DESCRIPTION
# Results current time and countdown only after display_results event

## Description

Considering that ``current_time`` is only used for the ``next word countdown`` at ``Results modal``, we can assign it accordingly and remove it from ``mount`` function.

To achieve this, it is important to differentiate between `display_results?` and `Wordle.is_ends?`. The former is the responsibility of LiveView, while the latter represents the result for the wordle_game and is independent of our LiveView implementation. 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [ ] Test
- [ ] Documentation
- [ ] Keep updated translations (.po)
- [x] Update changelog
